### PR TITLE
ProducerConsumer - five variants of the producer/consumer pattern

### DIFF
--- a/ProducerConsumer/ProducerConsumer.AsyncSemaphore/ProducerConsumer.AsyncSemaphore.csproj
+++ b/ProducerConsumer/ProducerConsumer.AsyncSemaphore/ProducerConsumer.AsyncSemaphore.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.AsyncSemaphore/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.AsyncSemaphore/Program.cs
@@ -1,0 +1,57 @@
+// 4) Async consumer pomocí SemaphoreSlim.WaitAsync().
+//
+// Rozdíl oproti Monitor.Wait:
+//   - Monitor.Wait BLOKUJE celé vlákno (vlákno z thread-poolu sedí a nic nedělá).
+//   - SemaphoreSlim.WaitAsync() vrátí Task – vlákno se uvolní pro jinou práci
+//     a continuation se naplánuje až při Release().
+//
+// Hodí se zejména v serverových/UI scénářích, kde je málo vláken a mnoho čekajících.
+
+const int N = 20;
+
+var queue = new Queue<int>();
+var gate = new object();
+var available = new SemaphoreSlim(0); // počet prvků, které čekají ve frontě
+bool finished = false;
+
+var producerTask = Task.Run(async () =>
+{
+	for (int i = 1; i <= N; i++)
+	{
+		lock (gate)
+		{
+			queue.Enqueue(i);
+		}
+		Console.WriteLine($"[P] enqueued {i}");
+		available.Release(); // signál: máme nový prvek
+		await Task.Delay(50);
+	}
+
+	finished = true;
+	available.Release(); // probudíme consumera, aby si všiml ukončení
+});
+
+var consumerTask = Task.Run(async () =>
+{
+	while (true)
+	{
+		await available.WaitAsync(); // ASYNC čekání – neblokuje vlákno
+
+		int item;
+		lock (gate)
+		{
+			if (queue.Count == 0)
+			{
+				if (finished) return;
+				continue;
+			}
+			item = queue.Dequeue();
+		}
+
+		Console.WriteLine($"[C] dequeued {item}");
+	}
+});
+
+await Task.WhenAll(producerTask, consumerTask);
+
+Console.WriteLine("Hotovo (async + SemaphoreSlim).");

--- a/ProducerConsumer/ProducerConsumer.AsyncSemaphore/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.AsyncSemaphore/Program.cs
@@ -27,7 +27,10 @@ var producerTask = Task.Run(async () =>
 		await Task.Delay(50);
 	}
 
-	finished = true;
+	lock (gate)
+	{
+		finished = true;
+	}
 	available.Release(); // probudíme consumera, aby si všiml ukončení
 });
 

--- a/ProducerConsumer/ProducerConsumer.Channel/ProducerConsumer.Channel.csproj
+++ b/ProducerConsumer/ProducerConsumer.Channel/ProducerConsumer.Channel.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.Channel/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.Channel/Program.cs
@@ -1,0 +1,36 @@
+// 5) Bonus: System.Threading.Channels – moderní řešení.
+//
+// Channel<T> je hotový thread-safe asynchronní buffer. Řeší za nás:
+//   - synchronizaci přístupu ke sdílené frontě
+//   - asynchronní čekání (WaitToReadAsync / ReadAllAsync)
+//   - signalizaci ukončení (Writer.Complete)
+//   - volitelně omezenou kapacitu a strategii backpressure (Channel.CreateBounded)
+
+using System.Threading.Channels;
+
+const int N = 20;
+
+var channel = Channel.CreateUnbounded<int>();
+
+var producerTask = Task.Run(async () =>
+{
+	for (int i = 1; i <= N; i++)
+	{
+		await channel.Writer.WriteAsync(i);
+		Console.WriteLine($"[P] wrote {i}");
+		await Task.Delay(50);
+	}
+	channel.Writer.Complete(); // consumer pozná konec – await foreach skončí sám
+});
+
+var consumerTask = Task.Run(async () =>
+{
+	await foreach (var item in channel.Reader.ReadAllAsync())
+	{
+		Console.WriteLine($"[C] read {item}");
+	}
+});
+
+await Task.WhenAll(producerTask, consumerTask);
+
+Console.WriteLine("Hotovo (Channel<T>).");

--- a/ProducerConsumer/ProducerConsumer.Lock/ProducerConsumer.Lock.csproj
+++ b/ProducerConsumer/ProducerConsumer.Lock/ProducerConsumer.Lock.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.Lock/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.Lock/Program.cs
@@ -1,0 +1,55 @@
+// 2) Synchronizace pomocí lock.
+//
+// Přístup ke sdílené frontě je atomický a thread-safe.
+// Stále ale zůstává busy waiting – consumer aktivně točí smyčku, dokud se neobjeví prvek.
+
+const int N = 20;
+
+var queue = new Queue<int>();
+var gate = new object();
+
+var producer = new Thread(() =>
+{
+	for (int i = 1; i <= N; i++)
+	{
+		lock (gate)
+		{
+			queue.Enqueue(i);
+		}
+		Console.WriteLine($"[P] enqueued {i}");
+		Thread.Sleep(50);
+	}
+});
+
+var consumer = new Thread(() =>
+{
+	int processed = 0;
+	while (processed < N)
+	{
+		int item = 0;
+		bool got = false;
+
+		lock (gate)
+		{
+			if (queue.Count > 0)
+			{
+				item = queue.Dequeue();
+				got = true;
+			}
+		}
+
+		if (got)
+		{
+			Console.WriteLine($"[C] dequeued {item}");
+			processed++;
+		}
+		// Pokud nic nebylo, smyčka se točí dál – stále busy waiting.
+	}
+});
+
+producer.Start();
+consumer.Start();
+producer.Join();
+consumer.Join();
+
+Console.WriteLine("Hotovo (lock).");

--- a/ProducerConsumer/ProducerConsumer.MonitorWait/ProducerConsumer.MonitorWait.csproj
+++ b/ProducerConsumer/ProducerConsumer.MonitorWait/ProducerConsumer.MonitorWait.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.MonitorWait/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.MonitorWait/Program.cs
@@ -1,0 +1,66 @@
+// 3) Monitor.Wait / Monitor.Pulse – odstranění busy waitingu.
+//
+// Consumer se uspí (Monitor.Wait), když je fronta prázdná, a producer ho probudí
+// (Monitor.Pulse) po vložení nového prvku. Žádné aktivní čekání.
+//
+// Proč WHILE místo IF? Po probuzení musíme znovu ověřit podmínku:
+//   - může nastat tzv. spurious wakeup,
+//   - při více konzumentech mohl být prvek mezitím odebrán jiným konzumentem.
+
+const int N = 20;
+
+var queue = new Queue<int>();
+var gate = new object();
+bool finished = false;
+
+var producer = new Thread(() =>
+{
+	for (int i = 1; i <= N; i++)
+	{
+		lock (gate)
+		{
+			queue.Enqueue(i);
+			Monitor.Pulse(gate); // probudíme jednoho čekajícího konzumenta
+		}
+		Console.WriteLine($"[P] enqueued {i}");
+		Thread.Sleep(50);
+	}
+
+	// Signalizace ukončení – consumer se probudí, vidí finished a skončí.
+	lock (gate)
+	{
+		finished = true;
+		Monitor.PulseAll(gate);
+	}
+});
+
+var consumer = new Thread(() =>
+{
+	while (true)
+	{
+		int item;
+		lock (gate)
+		{
+			while (queue.Count == 0 && !finished)
+			{
+				Monitor.Wait(gate); // uvolní zámek a usne, dokud nepřijde Pulse
+			}
+
+			if (queue.Count == 0 && finished)
+			{
+				return;
+			}
+
+			item = queue.Dequeue();
+		}
+
+		Console.WriteLine($"[C] dequeued {item}");
+	}
+});
+
+producer.Start();
+consumer.Start();
+producer.Join();
+consumer.Join();
+
+Console.WriteLine("Hotovo (Monitor.Wait/Pulse).");

--- a/ProducerConsumer/ProducerConsumer.Naive/ProducerConsumer.Naive.csproj
+++ b/ProducerConsumer/ProducerConsumer.Naive/ProducerConsumer.Naive.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/ProducerConsumer/ProducerConsumer.Naive/Program.cs
+++ b/ProducerConsumer/ProducerConsumer.Naive/Program.cs
@@ -1,0 +1,42 @@
+// 1) Naivní řešení – sdílená Queue<int> bez synchronizace.
+//
+// POZOR: tato varianta ZÁMĚRNĚ obsahuje chyby a slouží jen k demonstraci problémů:
+//   - race condition při souběžném přístupu (Queue<T> není thread-safe)
+//   - busy waiting konzumenta (vytěžuje CPU)
+//   - může dojít k pádu, zacyklení nebo vynechání prvku
+
+const int N = 20;
+
+var queue = new Queue<int>();
+
+var producer = new Thread(() =>
+{
+	for (int i = 1; i <= N; i++)
+	{
+		queue.Enqueue(i); // bez zámku – race condition
+		Console.WriteLine($"[P] enqueued {i}");
+		Thread.Sleep(50);
+	}
+});
+
+var consumer = new Thread(() =>
+{
+	int processed = 0;
+	while (processed < N)
+	{
+		// Aktivní čekání (busy waiting) – consumer pálí CPU dokola.
+		if (queue.Count > 0)
+		{
+			int item = queue.Dequeue(); // bez zámku – race condition
+			Console.WriteLine($"[C] dequeued {item}");
+			processed++;
+		}
+	}
+});
+
+producer.Start();
+consumer.Start();
+producer.Join();
+consumer.Join();
+
+Console.WriteLine("Hotovo (naivní).");

--- a/ProducerConsumer/ProducerConsumer.slnx
+++ b/ProducerConsumer/ProducerConsumer.slnx
@@ -1,0 +1,10 @@
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="README.md" />
+  </Folder>
+  <Project Path="ProducerConsumer.Naive/ProducerConsumer.Naive.csproj" />
+  <Project Path="ProducerConsumer.Lock/ProducerConsumer.Lock.csproj" />
+  <Project Path="ProducerConsumer.MonitorWait/ProducerConsumer.MonitorWait.csproj" />
+  <Project Path="ProducerConsumer.AsyncSemaphore/ProducerConsumer.AsyncSemaphore.csproj" />
+  <Project Path="ProducerConsumer.Channel/ProducerConsumer.Channel.csproj" />
+</Solution>

--- a/ProducerConsumer/README.md
+++ b/ProducerConsumer/README.md
@@ -1,0 +1,124 @@
+# Producer–Consumer (Async)
+
+## Zadání
+
+Implementuj jednoduchý systém se dvěma rolemi:
+
+* **Producer** generuje čísla `1..N`
+* **Consumer** je postupně zpracovává (např. vypisuje na konzoli)
+
+Mezi nimi je sdílený **buffer (fronta)**.
+
+---
+
+## Cíl
+
+* pochopit problém **Producer–Consumer**
+* zajistit **thread-safe přístup ke sdíleným datům**
+* odstranit **busy waiting**
+* seznámit se s **async přístupem ke konzumentovi**
+
+---
+
+## 1) Naivní řešení
+
+Začni implementací bez synchronizace:
+
+* sdílená `Queue<int>`
+* producer přidává prvky
+* consumer je odebírá v nekonečné smyčce
+
+### Otázky
+
+* Jaké problémy může řešení mít?
+* Co se stane při souběžném přístupu?
+* Jaké jsou dopady na CPU?
+
+---
+
+## 2) Synchronizace pomocí `lock`
+
+Uprav řešení tak, aby byl přístup ke frontě bezpečný:
+
+* použij `lock`
+* zajisti, že enqueue/dequeue je atomické
+
+### Otázky
+
+* Je řešení korektní?
+* Je efektivní?
+* Co dělá consumer, když je fronta prázdná?
+
+---
+
+## 3) Čekání místo aktivního cyklu
+
+Odstraň busy waiting:
+
+* použij `Monitor.Wait` / `Monitor.Pulse`
+* consumer čeká, když je fronta prázdná
+* producer probouzí consumera
+
+### Otázky
+
+* Proč je `while` nutné místo `if`?
+* Jaký je rozdíl oproti předchozí variantě?
+
+---
+
+## 4) Async consumer
+
+Převeď consumera na **asynchronní variantu**:
+
+* použij `SemaphoreSlim`
+* místo `Wait()` použij `WaitAsync()`
+
+### Požadavky
+
+* consumer nesmí blokovat thread při čekání
+* producer signalizuje dostupná data
+
+### Otázky
+
+* Jaký je rozdíl mezi `Wait()` a `WaitAsync()`?
+* Kdy je async řešení výhodné?
+
+---
+
+## 5) Bonus – moderní řešení
+
+Použij `Channel<T>`:
+
+* producer zapisuje pomocí `Writer`
+* consumer čte pomocí `await foreach`
+
+### Otázky
+
+* V čem je toto řešení jednodušší?
+* Jaké problémy řeší za tebe?
+
+---
+
+## Rozšíření
+
+* více producentů a konzumentů
+* omezená kapacita bufferu
+* ukončení consumera po dokončení práce
+* měření výkonu jednotlivých variant
+
+---
+
+## Očekávaný výstup
+
+Program vypíše čísla `1..N` v konzoli (pořadí nemusí být garantováno u více vláken).
+
+---
+
+## Poznámky
+
+* Zaměř se na **správnost i efektivitu**
+* Sleduj rozdíl mezi:
+
+  * blokováním threadu
+  * asynchronním čekáním
+* Nepoužívej hotová řešení (`BlockingCollection`, `Channel`) dříve než v bonusové části


### PR DESCRIPTION
## Summary

Adds a new **ProducerConsumer** learning project that walks through the producer/consumer pattern from a naive racy implementation up to a modern `Channel<T>`-based solution. Each variant is a standalone `net10.0` console app, all collected under a single `.slnx` solution.

## What's included

- **README.md** — task description, goals, questions for each variant, and notes (Czech).
- **ProducerConsumer.slnx** — multi-project solution.
- Five console apps, each a single `Program.cs` with top-level statements:
  1. `ProducerConsumer.Naive` — shared `Queue<int>` without synchronization. Intentionally buggy: race conditions and busy waiting.
  2. `ProducerConsumer.Lock` — atomic enqueue/dequeue via `lock`. Still busy waits.
  3. `ProducerConsumer.MonitorWait` — `Monitor.Wait` / `Monitor.Pulse`; consumer sleeps when the queue is empty. Uses `while` (not `if`) to handle spurious wakeups; `finished` flag + `PulseAll` for shutdown.
  4. `ProducerConsumer.AsyncSemaphore` — async consumer using `SemaphoreSlim.WaitAsync()` so the waiting thread is freed up.
  5. `ProducerConsumer.Channel` — modern solution using `System.Threading.Channels` and `await foreach`, with `Writer.Complete()` for shutdown.

Each variant produces N=20 items so the producer/consumer interleaving is visible in the console output.

## Test plan

- [x] `dotnet build ProducerConsumer/ProducerConsumer.slnx` — succeeds, 0 warnings, 0 errors.
- [x] All five variants run end-to-end and print items 1..20 as expected.
- [ ] Reviewer skim: README content matches the assignment text verbatim; comments in each `Program.cs` are aligned with the matching README section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)